### PR TITLE
IsBrowserInitializedChanged should be raised when uninitialized.

### DIFF
--- a/CefSharp.Wpf.HwndHost/ChromiumWebBrowser.cs
+++ b/CefSharp.Wpf.HwndHost/ChromiumWebBrowser.cs
@@ -1130,10 +1130,10 @@ namespace CefSharp.Wpf.HwndHost
         /// <param name="newValue">if set to <c>true</c> [new value].</param>
         protected virtual void OnIsBrowserInitializedChanged(bool oldValue, bool newValue)
         {
+            IsBrowserInitializedChanged?.Invoke(this, EventArgs.Empty);
+
             if (newValue && !IsDisposed)
             {
-                IsBrowserInitializedChanged?.Invoke(this, EventArgs.Empty);
-
                 var task = this.GetZoomLevelAsync();
                 task.ContinueWith(previous =>
                 {

--- a/CefSharp.Wpf.HwndHost/ChromiumWebBrowser.cs
+++ b/CefSharp.Wpf.HwndHost/ChromiumWebBrowser.cs
@@ -1130,8 +1130,6 @@ namespace CefSharp.Wpf.HwndHost
         /// <param name="newValue">if set to <c>true</c> [new value].</param>
         protected virtual void OnIsBrowserInitializedChanged(bool oldValue, bool newValue)
         {
-            IsBrowserInitializedChanged?.Invoke(this, EventArgs.Empty);
-
             if (newValue && !IsDisposed)
             {
                 var task = this.GetZoomLevelAsync();
@@ -1153,6 +1151,8 @@ namespace CefSharp.Wpf.HwndHost
                     }
                 }, TaskContinuationOptions.ExecuteSynchronously);
             }
+
+            IsBrowserInitializedChanged?.Invoke(this, EventArgs.Empty);
         }
 
         /// <summary>


### PR DESCRIPTION
In CefSharp.Wpf, `IsBrowserInitializedChanged` is raised [here](https://github.com/cefsharp/CefSharp/blob/master/CefSharp.Wpf/ChromiumWebBrowser.cs#L1278) no matter initialized or uninitialized.
But in CefSharp.Wpf.HwndHost, it's only raised when initialized.
The behaviors of them should be the same.