### PR TITLE
Use Math.Round to caculate win32 physical size.

### DIFF
--- a/CefSharp.Wpf.HwndHost/ChromiumWebBrowser.cs
+++ b/CefSharp.Wpf.HwndHost/ChromiumWebBrowser.cs
@@ -1680,8 +1680,8 @@ namespace CefSharp.Wpf.HwndHost
             {
                 if (dpiScale > 1)
                 {
-                    width = (int)(width * dpiScale);
-                    height = (int)(height * dpiScale);
+                    width = (int)Math.Round(width * dpiScale);
+                    height = (int)Math.Round(height * dpiScale);
                 }
 
                 managedCefBrowserAdapter.Resize(width, height);


### PR DESCRIPTION
At some dpi, dpi * wpf size may get non-integer win32 physical size. And convert it to integer directly may cause that the browser size is one pixel smaller than expected.