### PR TITLE
Set --hide-crash-restore-bubble and --disable-chrome-login-prompt

### DIFF
--- a/CefSharp.Wpf.HwndHost/CefSettings.cs
+++ b/CefSharp.Wpf.HwndHost/CefSettings.cs
@@ -9,5 +9,18 @@ namespace CefSharp.Wpf.HwndHost
     /// </summary>
     public class CefSettings : CefSettingsBase
     {
+        /// <summary>
+        /// Intialize with default values
+        /// </summary>
+        public CefSettings() : base()
+        {
+            // CEF doesn't call GetAuthCredentials unless the Chrome login prompt is disabled
+            // https://github.com/chromiumembedded/cef/issues/3603 
+            CefCommandLineArgs.Add("disable-chrome-login-prompt");
+
+            // Disable "Restore pages" popup after incorrect shutdown
+            // https://github.com/chromiumembedded/cef/issues/3767
+            CefCommandLineArgs.Add("hide-crash-restore-bubble");
+        }
     }
 }


### PR DESCRIPTION
Resolves https://github.com/cefsharp/CefSharp/issues/4830 and https://github.com/cefsharp/CefSharp/issues/4903

Set `--hide-crash-restore-bubble` by default to prevent Chromium window from opening after unsuccessful shutdown.

Set `--disable-chrome-login-prompt` by default to disable Chrome login prompt and call GetAuthCredentials.