### PR TITLE
Focus on browser when going fullscreen to shift keyboard focus

### DIFF
--- a/CefSharp.Wpf.HwndHost.Example/Handlers/DisplayHandler.cs
+++ b/CefSharp.Wpf.HwndHost.Example/Handlers/DisplayHandler.cs
@@ -33,6 +33,7 @@ namespace CefSharp.Wpf.HwndHost.Example.Handlers
                         WindowState = WindowState.Maximized,
                         Content = webBrowser
                     };
+                    fullScreenWindow.Loaded += (_,_) => webBrowser.Focus();
 
                     fullScreenWindow.ShowDialog();
                 }


### PR DESCRIPTION
I noticed it doesn't take focus properly when opening so when going fullscreen and hitting escape nothing happens until you click.  The normal WPF display handler uses the same code, not sure if it has the same issue or if this is a unique to hwndhost thing.

While an anonymous delagate is used for the event handler and we contain a scoped reference to webBrowser i think both are still GC'ed properly given the disposal pattern here.

Noticed this is failing due to c# 9 styling.   Not sure if we want a <LangVersion> or just not use discards. 