### PR TITLE
Fix: Allow any RequestContext that inherits from Core.RequestContext

### DIFF
--- a/CefSharp.Wpf.HwndHost/ChromiumWebBrowser.cs
+++ b/CefSharp.Wpf.HwndHost/ChromiumWebBrowser.cs
@@ -250,9 +250,9 @@ namespace CefSharp.Wpf.HwndHost
                     throw new Exception("Browser has already been created. RequestContext must be " +
                                         "set before the underlying CEF browser is created.");
                 }
-                if (value != null && value.GetType() != typeof(RequestContext))
+                if (value != null && !Core.ObjectFactory.RequestContextType.IsAssignableFrom(value.UnWrap().GetType()))
                 {
-                    throw new Exception(string.Format("RequestContxt can only be of type {0} or null", typeof(RequestContext)));
+                    throw new Exception(string.Format("RequestContext can only be of type {0} or null", Core.ObjectFactory.RequestContextType));
                 }
                 requestContext = value;
             }


### PR DESCRIPTION
Matches non HwndHost check

Fixes #30 